### PR TITLE
Move attachments out from template to send_email

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,10 +1,11 @@
 Changelog
 =========
 
-0.9.4 (unreleased)
+0.10.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Move method of adding attachments out of the template
+  and require attachments to be passed as an argument to ``send_email()``. [Alex Bliskovsky]
 
 
 0.9.3 (2015-08-27)

--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ For those wondering, `Ogmios <https://en.wikipedia.org/wiki/Ogmios>`_ is just th
 Quickstart
 ==========
 
-Install with ``pip``: ``pip install django-ogmios``.
+Install from PyPI with ``pip``: ``pip install django-ogmios``.
 
 ``yourproject/templates/mail/template.html``::
 
@@ -25,11 +25,6 @@ Install with ``pip``: ``pip install django-ogmios``.
     headers:
       Reply-To: Jaqueline <jaqueline@example.net>
       Organization: Example.org, Inc.
-    attachments:
-      - /absolute/path/file.odt
-      - relative/path/file.ods
-      - {{ file.path }}
-      - ['awesomereport.odt', 'mydocuments/crappy_report.odt', 'application/vnd.oasis.opendocument.text-template']
     ---
     {% load special_filter %}
 
@@ -44,10 +39,17 @@ Install with ``pip``: ``pip install django-ogmios``.
 
     import ogmios
 
-    ogmios.send_email('mail/template.html', {'item_list': ['Hello']})
+    ogmios.send_email('mail/template.html',
+                      {'item_list': ['Hello']},
+                      attachments=[{
+                           'path': '/path/to/file/',
+                           'name': 'file.txt',
+                           'type': 'text/plain',
+                       }])
 
 
 This will render the content as markdown, and send the email with an HTML part and a Plaintext part.
+For attachments, it is possible to just specify the path, or the path, filename and mimetype.
 
 Tips
 ====

--- a/ogmios_tests/app/templates/attachment.md
+++ b/ogmios_tests/app/templates/attachment.md
@@ -2,8 +2,6 @@ from: John Doe <john@example.com>
 to: Jane Doe <jane@example.com>
 subject: Hi there
 content-type: markdown
-attachments:
-    - {{ file }}
 ---
 
 Hello

--- a/ogmios_tests/app/templates/renamed_attachment.md
+++ b/ogmios_tests/app/templates/renamed_attachment.md
@@ -1,9 +1,0 @@
-from: John Doe <john@example.com>
-to: Jane Doe <jane@example.com>
-subject: Hi there
-content-type: markdown
-attachments:
-    - ['file.txt', '{{ file }}', 'text/plain']
----
-
-Hello

--- a/ogmios_tests/test.py
+++ b/ogmios_tests/test.py
@@ -43,12 +43,32 @@ class SendEmailTest(TestCase):
 
             send_email('attachment.md',
                        context={},
-                       attachments=[{'path': fp.name}]
+                       attachments=[fp.name]
             )
 
         assert len(mail.outbox) == 1
         assert len(mail.outbox[0].attachments) == 1
         assert mail.outbox[0].attachments[0][1] == content
+
+    def test_send_renamed_attachment_without_mimetype(self):
+        content = 'Some content'
+
+        with NamedTemporaryFile() as fp:
+            # Encode to bytes for Python 3 compatibility.
+            fp.write(content.encode('utf-8'))
+            fp.flush()
+
+            send_email('attachment.md',
+                       context={},
+                       attachments=[{
+                           'path': fp.name,
+                           'name': 'file_test.txt',
+                       }])
+
+        assert len(mail.outbox) == 1
+        assert len(mail.outbox[0].attachments) == 1
+        assert mail.outbox[0].attachments[0][1] == content
+        assert mail.outbox[0].attachments[0][0] == 'file_test.txt'
 
     def test_rename_attachment(self):
         content = 'Some content'

--- a/ogmios_tests/test.py
+++ b/ogmios_tests/test.py
@@ -3,7 +3,7 @@ from tempfile import NamedTemporaryFile
 from django.core import mail
 from django.test import TestCase, override_settings
 
-from ogmios import send_email
+from ogmios import send_email, OgmiosError
 
 CACHED_TEMPLATE_LOADER_SETTINGS = [
     {
@@ -41,7 +41,10 @@ class SendEmailTest(TestCase):
             fp.write(content)
             fp.flush()
 
-            send_email('attachment.md', {'file': fp.name})
+            send_email('attachment.md',
+                       context={},
+                       attachments=[{'path': fp.name}]
+            )
 
         assert len(mail.outbox) == 1
         assert len(mail.outbox[0].attachments) == 1
@@ -55,12 +58,31 @@ class SendEmailTest(TestCase):
             fp.write(content.encode('utf-8'))
             fp.flush()
 
-            send_email('renamed_attachment.md', {'file': fp.name})
+            send_email('attachment.md',
+                       context={},
+                       attachments=[{
+                           'path': fp.name,
+                           'name': 'file.txt',
+                           'type': 'text/plain',
+                       }])
 
         assert len(mail.outbox) == 1
         assert len(mail.outbox[0].attachments) == 1
         assert mail.outbox[0].attachments[0][1] == content
         assert mail.outbox[0].attachments[0][0] == 'file.txt'
+
+    def test_attachment_validation(self):
+        content = 'Some content'
+
+        with NamedTemporaryFile() as fp:
+            fp.write(content.encode('utf-8'))
+            fp.flush()
+            with self.assertRaises(OgmiosError):
+                send_email('attachment.md',
+                           context={},
+                           attachments=[{
+                               'name': 'file.txt'
+                           }])
 
     def test_markdown(self):
         send_email('markdown.md', {})

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import os
 from setuptools import setup
 from setuptools.command.test import test as TestCommand
 
-version = '0.9.4.dev0'
+version = '0.10.0.dev0'
 
 
 def read_file(fname):


### PR DESCRIPTION
Defining attachments in the template did not allow for a template
to have a variable number of attachments. This patch allows templates
to be defined independently of the attachments they carry.
