### PR TITLE
Add a method to get the EmailMessage object without sending it

### DIFF
--- a/ogmios/__init__.py
+++ b/ogmios/__init__.py
@@ -165,7 +165,7 @@ class EmailSender(object):
         elif self.data['content-type'] == TYPE_HTML:
             return self.render_string(self.content[1])
 
-    def send(self):
+    def build_message(self):
         to = self.get_recipients('to')
         if len(to) == 0:
             raise EmailTemplateError("You gotta give some recipients.")
@@ -192,8 +192,11 @@ class EmailSender(object):
             email.attach_alternative(self.html, 'text/html')
 
         self.handle_attachments(email)
+        return email
 
-        email.send()
+    def send(self):
+        message = self.build_message()
+        return message.send()
 
 
 def send_email(template, context, sender_class=EmailSender, attachments=None):

--- a/ogmios_tests/test.py
+++ b/ogmios_tests/test.py
@@ -3,7 +3,7 @@ from tempfile import NamedTemporaryFile
 from django.core import mail
 from django.test import TestCase, override_settings
 
-from ogmios import send_email, OgmiosError
+from ogmios import send_email, OgmiosError, EmailSender
 
 CACHED_TEMPLATE_LOADER_SETTINGS = [
     {
@@ -150,3 +150,10 @@ class SendEmailTest(TestCase):
         assert message.is_multipart()
         content_types = {m.get_content_type() for m in message.get_payload()}
         assert content_types == {'text/plain', 'text/html'}
+
+
+class EmailSenderTest(TestCase):
+    def test_build_message(self):
+        to = 'user@example.com'
+        message = EmailSender('to.md', {'to': to}).build_message()
+        assert message.to == [to]


### PR DESCRIPTION
This allows passing many ogmios emails at a time to Django's send_messages function.
